### PR TITLE
Add Processing Foundation projects

### DIFF
--- a/_pages/projects-processing.md
+++ b/_pages/projects-processing.md
@@ -1,0 +1,27 @@
+---
+title: Software Projects Hosted By The Processing Foundation
+excerpt: A list of projects supported by the Processing Foundation
+layout: default
+permalink: /projects-processing-foundation
+nav_exclude: true
+---
+
+The Processing Foundation hosts a variety of major open source projects that serve as creative tools for artists, educators, and programmers alike. These projects encourage experimentation with code as a medium of expression and learning, and they aim to make coding accessible to people from diverse backgrounds and disciplines.
+
+<h2>Processing Foundation Subprojects</h2>
+
+- **Processing (Java)**
+  https://processing.org/
+  A flexible software sketchbook and a language for learning how to code within the context of visual arts. Processing is aimed at creating interactive visual applications with ease.
+- **p5.js**
+  https://p5js.org/
+  A JavaScript library inspired by Processing, which makes it easy to create graphics and interactive content for the web. p5.js is focused on making creative coding more accessible, especially for beginners.
+- **Processing for Android**
+  https://android.processing.org
+  A version of Processing designed for creating native Android applications, allowing developers to write code that runs on Android devices with the same ease as desktop sketches.
+- **Processing Python**
+  https://py.processing.org
+  A mode for Processing that allows users to write sketches using the Python programming language, providing an alternative syntax while retaining the core features of Processing.
+- **Processing for Pi**
+  https://pi.processing.org
+  A specialized version of Processing optimized for the Raspberry Pi, aimed at leveraging the unique capabilities of the popular single-board computer for creative projects.

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -16,5 +16,6 @@ These listings are updated on a best-effort basis, and provide just a snapshot i
 - Software Freedom Conservancy projects.
 - [NumFocus](projects-numfocus) projects.
 - [Software In The Public Interest](projects-spi) projects.
+- [Processing Foundation](projects-processing) projects.
 
 Project listings may not be current.  Various helper scripts in [assets/ruby/scrapers.rb](https://github.com/Punderthings/fossfoundation/tree/main/assets/ruby/scrapers.rb) are used to semi-automate enumerating foundation projects and creating a simplified per-foundation `.csv` listing.


### PR DESCRIPTION
This add key subprojects of the Processing Foundation. 

Note: I have hardcoded the list of projects. The Processing Foundation does maintain a projects page (https://processingfoundation.org/projects) but it is incomplete. Besides, given a planned website redesign in the near future, building a custom scraper feels somewhat wasteful for now. Let me know if you think otherwise.

Corresponding PR to add the Processing Foundation: https://github.com/Punderthings/fossfoundation/pull/33